### PR TITLE
Dynamic Queue logic to create queues and bind them

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ client.on('channel', (channel) => {
     console.log("Published ------ " + message.content.toString());
     client.ack(message);
   });
+  client.createDynamicQueue("TestExchange",'createQueueTest',[{x:1,y:2},{x:11,y:22}]);
 });
-
 client.connect();
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voicenter-team/failover-amqp-pool",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "amqp pool client",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Dynamic Queue logic to create queues and bind them on runtime 
add two functions, Public  createDynamicQueue and internal which we used to recover _reconfigureDynamicQueue